### PR TITLE
findProtoFiles: Add iterate permission to Dir.open to fix path search bug (Fixes #2)

### DIFF
--- a/src/parser/fs/paths.zig
+++ b/src/parser/fs/paths.zig
@@ -19,7 +19,7 @@ const std = @import("std");
 /// Returns an ArrayList containing the absolute paths to all found .proto files
 /// Caller owns the returned ArrayList and must call deinit() on it
 pub fn findProtoFiles(allocator: std.mem.Allocator, basePath: []const u8) !std.ArrayList([]const u8) {
-    var dir = try std.fs.cwd().openDir(basePath, .{});
+    var dir = try std.fs.cwd().openDir(basePath, .{ .iterate = true });
     defer dir.close();
 
     var walker = try dir.walk(allocator);


### PR DESCRIPTION
Fixes #2: Directories are not opened with iterate permissions.  

See the [Zig documentation on Dir.OpenOptions](https://ziglang.org/documentation/master/std/#std.fs.Dir.OpenOptions) as mentioned in the issue replies: [#2 comment](https://github.com/octopus-foundation/gremlin.zig/issues/2#issuecomment-2483172363).

Tested on zig version 0.14.0-dev.2271+f845fa04a

