### PR TITLE
Zig updates

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,9 +1,8 @@
 .{
-    .name = "gremlin",
+    .name = .gremlin,
     .version = "0.0.0",
+    .fingerprint = 0x52f178c9d53d6b13,
     .minimum_zig_version = "0.14.0",
 
-    .paths = .{
-        ""
-    },
+    .paths = .{""},
 }

--- a/src/parser/entries/scoped-name.zig
+++ b/src/parser/entries/scoped-name.zig
@@ -143,7 +143,7 @@ pub const ScopedName = struct {
             }
 
             var parent = try p.clone();
-            const name = parent.pop();
+            const name = parent.pop().?;
             const full = try std.mem.join(self.allocator, ".", p.items);
 
             return ScopedName{


### PR DESCRIPTION
Small updates for zig 0.14.0 release.

[e5f12d3](https://github.com/octopus-foundation/gremlin.zig/commit/e5f12d30e4f99f2df5d2f671ec27a55931d6638c)     `build.zig.zon` got a new `fingerprint` field, and `name` is now an enum literal.

[71b78a9](https://github.com/octopus-foundation/gremlin.zig/commit/71b78a9c8e69dad66787edae0fe46b3930eebe9c) the `pop()` function implementation was recently changed to the `popOrNull()` implementation.  See these Zig PRs: [19406](https://github.com/ziglang/zig/pull/19406) for the reasoning, and [22720](https://github.com/ziglang/zig/pull/22720) for the actual change.

All Tests passed with zig version `0.14.0`