### PR TITLE
update to work with Zig 0.16.x-dev

### DIFF
--- a/src/codegen/gen/enum.zig
+++ b/src/codegen/gen/enum.zig
@@ -114,9 +114,10 @@ pub const ZigEnum = struct {
     ///
     /// Returns: A newly allocated string containing the Zig enum code
     pub fn createEnumDef(self: *const ZigEnum, allocator: std.mem.Allocator) ![]const u8 {
-        var buffer = try std.ArrayList(u8).initCapacity(allocator, 1024);
-        errdefer buffer.deinit(allocator);
-        var writer = buffer.writer(allocator);
+        const buffer = try allocator.alloc(u8, 32 * 1024);
+        defer allocator.free(buffer);
+
+        var writer = std.Io.Writer.fixed(buffer);
 
         try writer.print("pub const {s} = enum(i32) {{\n", .{self.const_name});
 
@@ -126,7 +127,7 @@ pub const ZigEnum = struct {
         }
 
         try writer.writeAll("};\n");
-        return buffer.toOwnedSlice(allocator);
+        return allocator.dupe(u8, writer.buffered());
     }
 
     /// Frees all resources associated with this enum definition.

--- a/src/codegen/gen/fields/bytes.zig
+++ b/src/codegen/gen/fields/bytes.zig
@@ -59,7 +59,11 @@ fn formatStringLiteral(allocator: std.mem.Allocator, str: []const u8) ![]const u
             '"' => try result.appendSlice(allocator, "\\\""),
 
             // All other characters are converted to hex for consistent representation
-            else => try std.fmt.format(result.writer(allocator), "\\x{X:0>2}", .{c}),
+            else => {
+                var buf: [32]u8 = undefined;
+                const hex = try std.fmt.bufPrint(&buf, "\\x{X:0>2}", .{c});
+                try result.appendSlice(allocator, hex);
+            },
         }
     }
     try result.appendSlice(allocator, "\"");

--- a/src/codegen/gen/import.zig
+++ b/src/codegen/gen/import.zig
@@ -132,7 +132,8 @@ pub fn importResolve(
     const rel_to_proto = if (well_known_types.isWellKnownImport(import_path))
         try allocator.dupe(u8, import_path)
     else
-        try std.fs.path.relativePosix(allocator, proto_root, import_path);
+        // TODO(jae): Test this change of having to add "cwd"
+        try std.fs.path.relativePosix(allocator, ".", proto_root, import_path);
     defer allocator.free(rel_to_proto);
 
     // Generate output path in target directory
@@ -140,7 +141,8 @@ pub fn importResolve(
     defer allocator.free(out_path);
 
     // Get path relative to project root
-    const rel_to_project = try std.fs.path.relativePosix(allocator, project_root, out_path);
+    // TODO(jae): Test this change of having to add "cwd"
+    const rel_to_project = try std.fs.path.relativePosix(allocator, ".", project_root, out_path);
     defer allocator.free(rel_to_project);
 
     // Generate import alias from filename

--- a/step.zig
+++ b/step.zig
@@ -58,10 +58,11 @@ fn make(step: *std.Build.Step, _: std.Build.Step.MakeOptions) !void {
     const target_path = try ps.gen_output.getPath3(b, step).toString(b.allocator);
     const build_path = b.build_root.path orelse @panic("build path unknown");
 
-    const proto_path_resolved = try std.Build.Cache.Directory.cwd().handle.realpathAlloc(b.allocator, proto_path);
+    const proto_path_resolved = try std.Build.Cache.Directory.cwd().handle.realPathFileAlloc(b.graph.io, proto_path, b.allocator);
     defer b.allocator.free(proto_path_resolved);
 
     generateProtobuf(
+        b.graph.io,
         b.allocator,
         proto_path_resolved,
         target_path,


### PR DESCRIPTION
Did the bare minimum to get this working in Zig 0.16.X-dev. I'm not expecting this to be accepted or merged but because I've done these modifications for myself, I figured I'd at least put up a PR.

- createEnumDef is limited to 32kb now, this needs more thought/effort, might be worth fixing this to avoid using the legacy writer before updating upstream to Zig 0.16.X
- `zig build test` runs successfully on Linux.
- I'm unsure of the uses of `realPath` and if they're correct.

Fixes #14